### PR TITLE
Avoid mutating ItemStacks during polymer filtering

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.17.2
 loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=0.2.2+1.21.1-beta.16
+mod_version=0.2.2+1.21.1-beta.20
 maven_group=com.zefir.servercosmetics
 archives_base_name=servercosmetics
 

--- a/src/main/java/com/zefir/servercosmetics/data/CustomItemRegistry.java
+++ b/src/main/java/com/zefir/servercosmetics/data/CustomItemRegistry.java
@@ -230,6 +230,7 @@ public class CustomItemRegistry {
         }
 
         PolymerModelData polymerModel;
+        Integer blockingModelData = null;
         try {
             if (baseItem instanceof ArmorItem armorItem && armorItem.getType() != ArmorItem.Type.BODY) {
 
@@ -243,6 +244,16 @@ public class CustomItemRegistry {
 
             } else {
                 polymerModel = PolymerResourcePackUtils.requestModel(baseItem, Identifier.of(ServerCosmetics.MOD_ID, "item/" + cosmeticOrSkinId));
+                if (baseItem instanceof net.minecraft.item.ShieldItem) {
+                    try {
+                        PolymerModelData blockingModel = PolymerResourcePackUtils.requestModel(baseItem, Identifier.of(ServerCosmetics.MOD_ID, "item/" + cosmeticOrSkinId + "_blocking"));
+                        blockingModelData = blockingModel.value();
+                    } catch (Exception ignored) {
+                        if (ServerCosmetics.LOGGER.isDebugEnabled()) {
+                            ServerCosmetics.LOGGER.debug("No blocking model defined for shield cosmetic '{}'.", cosmeticOrSkinId);
+                        }
+                    }
+                }
             }
         } catch (Exception e) {
             ServerCosmetics.LOGGER.error("Failed to request model for item id '{}' with base item '{}': {}", cosmeticOrSkinId, baseMaterialId, e.getMessage());
@@ -259,6 +270,8 @@ public class CustomItemRegistry {
                         nbt -> nbt.putString(NEW_NBT_KEY_CUSTOM_ITEM_ID, cosmeticOrSkinId))
         );
 
+        Utils.initializeModelData(itemStack, polymerModel.value(), blockingModelData);
+
         if (baseItem instanceof ArmorItem armorItem && armorItem.getType() != ArmorItem.Type.BODY) {
             String armorId = cosmeticOrSkinId.replace("_" + armorItem.getType().getName().toLowerCase(), "");
             PolymerArmorModel armorModel = PolymerResourcePackUtils.requestArmor(id(armorId));
@@ -272,7 +285,6 @@ public class CustomItemRegistry {
         }
 
         itemStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(polymerModel.value()));
-        Utils.applyModelOverride(itemStack, polymerModel.value());
         itemStack.set(DataComponentTypes.CUSTOM_NAME, displayName);
 
         return itemStack;
@@ -287,7 +299,6 @@ public class CustomItemRegistry {
             default -> Items.STONE;
         };
     }
-
     // --- Accessor methods ---
 
     public static CustomItemEntry getCosmetic(String id) {

--- a/src/main/java/com/zefir/servercosmetics/data/CustomItemRegistry.java
+++ b/src/main/java/com/zefir/servercosmetics/data/CustomItemRegistry.java
@@ -272,6 +272,7 @@ public class CustomItemRegistry {
         }
 
         itemStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(polymerModel.value()));
+        Utils.applyModelOverride(itemStack, polymerModel.value());
         itemStack.set(DataComponentTypes.CUSTOM_NAME, displayName);
 
         return itemStack;
@@ -279,10 +280,10 @@ public class CustomItemRegistry {
 
     private static Item getItemFor(ArmorItem.Type type) {
         return switch (type) {
-            case ArmorItem.Type.HELMET -> Items.LEATHER_HELMET;
-            case ArmorItem.Type.CHESTPLATE -> Items.LEATHER_CHESTPLATE;
-            case ArmorItem.Type.LEGGINGS -> Items.LEATHER_LEGGINGS;
-            case ArmorItem.Type.BOOTS -> Items.LEATHER_BOOTS;
+            case HELMET -> Items.LEATHER_HELMET;
+            case CHESTPLATE -> Items.LEATHER_CHESTPLATE;
+            case LEGGINGS -> Items.LEATHER_LEGGINGS;
+            case BOOTS -> Items.LEATHER_BOOTS;
             default -> Items.STONE;
         };
     }

--- a/src/main/java/com/zefir/servercosmetics/gui/ItemSkinsGUI.java
+++ b/src/main/java/com/zefir/servercosmetics/gui/ItemSkinsGUI.java
@@ -8,11 +8,11 @@ import com.zefir.servercosmetics.gui.filters.PermissionFilter;
 import com.zefir.servercosmetics.gui.filters.SelectedItemFilter;
 import com.zefir.servercosmetics.gui.providers.ItemSkinProvider;
 import com.zefir.servercosmetics.util.GUIUtils;
+import com.zefir.servercosmetics.util.Utils;
 import eu.pb4.sgui.api.ClickType;
 import eu.pb4.sgui.api.GuiHelpers;
 import eu.pb4.sgui.api.elements.GuiElementBuilder;
 import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.NbtComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.screen.slot.SlotActionType;
@@ -20,9 +20,7 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 
-import static com.zefir.servercosmetics.config.ConfigManager.COSMETICS_GUI_CONFIG;
 import static com.zefir.servercosmetics.config.ConfigManager.ITEM_SKINS_GUI_CONFIG;
-import static com.zefir.servercosmetics.datafixer.NbtDatafixer.NEW_NBT_KEY_CUSTOM_ITEM_ID;
 
 public class ItemSkinsGUI {
     public static int openItemSkinsGui(CommandContext<ServerCommandSource> ctx) {
@@ -101,11 +99,11 @@ public class ItemSkinsGUI {
 
         ((SelectedItemFilter) (gui.getFilterManager().getFilter("selected-item").filter())).setSelectedItem(targetStack.getItem());
 
-        GUIUtils.setUpButton(gui, ITEM_SKINS_GUI_CONFIG.getButtonConfig("removeSkin"), () -> {
-                targetStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp -> comp.apply(nbt -> nbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID)));
-                targetStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+    GUIUtils.setUpButton(gui, ITEM_SKINS_GUI_CONFIG.getButtonConfig("removeSkin"), () -> {
+        Utils.clearCosmeticIdentifiers(targetStack);
+        targetStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
 
-                gui.setSlot(ItemSkinsGUIConfig.getItemSlot(), targetStack.copy());
+        gui.setSlot(ItemSkinsGUIConfig.getItemSlot(), targetStack.copy());
         });
     }
 }

--- a/src/main/java/com/zefir/servercosmetics/gui/ItemSkinsGUI.java
+++ b/src/main/java/com/zefir/servercosmetics/gui/ItemSkinsGUI.java
@@ -12,7 +12,6 @@ import com.zefir.servercosmetics.util.Utils;
 import eu.pb4.sgui.api.ClickType;
 import eu.pb4.sgui.api.GuiHelpers;
 import eu.pb4.sgui.api.elements.GuiElementBuilder;
-import net.minecraft.component.DataComponentTypes;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.screen.slot.SlotActionType;
@@ -101,7 +100,6 @@ public class ItemSkinsGUI {
 
     GUIUtils.setUpButton(gui, ITEM_SKINS_GUI_CONFIG.getButtonConfig("removeSkin"), () -> {
         Utils.clearCosmeticIdentifiers(targetStack);
-        targetStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
 
         gui.setSlot(ItemSkinsGUIConfig.getItemSlot(), targetStack.copy());
         });

--- a/src/main/java/com/zefir/servercosmetics/gui/actions/ApplySkinAction.java
+++ b/src/main/java/com/zefir/servercosmetics/gui/actions/ApplySkinAction.java
@@ -2,6 +2,7 @@ package com.zefir.servercosmetics.gui.actions;
 
 import com.zefir.servercosmetics.data.CustomItemEntry;
 import com.zefir.servercosmetics.gui.core.IItemAction;
+import com.zefir.servercosmetics.util.Utils;
 import eu.pb4.sgui.api.gui.SimpleGui;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.CustomModelDataComponent;
@@ -27,7 +28,14 @@ public class ApplySkinAction implements IItemAction {
         targetItemStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp ->
                 comp.apply(nbt -> nbt.putString(NEW_NBT_KEY_CUSTOM_ITEM_ID, entry.id()))
         );
-//        targetItemStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, entry.itemStack().getOrDefault(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(0)));
+        CustomModelDataComponent modelData = entry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
+        if (modelData != null) {
+            targetItemStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, modelData);
+            Utils.applyModelOverride(targetItemStack, modelData.value());
+        } else {
+            targetItemStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+            Utils.clearModelOverride(targetItemStack);
+        }
 
         if (entry.itemStack().getItem() instanceof ArmorItem armorItem && armorItem.getType() != ArmorItem.Type.BODY) {
             // TODO: Rewrite the whole itemskins thing

--- a/src/main/java/com/zefir/servercosmetics/gui/actions/ApplySkinAction.java
+++ b/src/main/java/com/zefir/servercosmetics/gui/actions/ApplySkinAction.java
@@ -5,7 +5,6 @@ import com.zefir.servercosmetics.gui.core.IItemAction;
 import com.zefir.servercosmetics.util.Utils;
 import eu.pb4.sgui.api.gui.SimpleGui;
 import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.CustomModelDataComponent;
 import net.minecraft.component.type.NbtComponent;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ItemStack;
@@ -28,14 +27,7 @@ public class ApplySkinAction implements IItemAction {
         targetItemStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp ->
                 comp.apply(nbt -> nbt.putString(NEW_NBT_KEY_CUSTOM_ITEM_ID, entry.id()))
         );
-        CustomModelDataComponent modelData = entry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
-        if (modelData != null) {
-            targetItemStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, modelData);
-            Utils.applyModelOverride(targetItemStack, modelData.value());
-        } else {
-            targetItemStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
-            Utils.clearModelOverride(targetItemStack);
-        }
+            Utils.copyModelData(entry.itemStack(), targetItemStack);
 
         if (entry.itemStack().getItem() instanceof ArmorItem armorItem && armorItem.getType() != ArmorItem.Type.BODY) {
             // TODO: Rewrite the whole itemskins thing

--- a/src/main/java/com/zefir/servercosmetics/mixin/ServerPlayerEntityMixin_cosmetics.java
+++ b/src/main/java/com/zefir/servercosmetics/mixin/ServerPlayerEntityMixin_cosmetics.java
@@ -5,6 +5,7 @@ import com.zefir.servercosmetics.ext.ICosmetic;
 import com.zefir.servercosmetics.ext.ICosmetics;
 import com.zefir.servercosmetics.util.ArmorCosmetic;
 import com.zefir.servercosmetics.util.BodyCosmetic;
+import com.zefir.servercosmetics.util.Utils;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -44,6 +45,7 @@ public abstract class ServerPlayerEntityMixin_cosmetics implements ICosmetics {
     @Override
     public void tickArmor(){
         cosmeticsList.forEach(ICosmetic::tick);
+        Utils.updateShieldBlockingState((ServerPlayerEntity) (Object) this);
     }
 
     @Override

--- a/src/main/java/com/zefir/servercosmetics/util/Utils.java
+++ b/src/main/java/com/zefir/servercosmetics/util/Utils.java
@@ -3,6 +3,7 @@ package com.zefir.servercosmetics.util;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.datafixers.util.Pair;
 import com.zefir.servercosmetics.ServerCosmetics;
 import com.zefir.servercosmetics.data.CustomItemEntry;
 import com.zefir.servercosmetics.data.CustomItemRegistry;
@@ -20,18 +21,23 @@ import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.CustomModelDataComponent;
 import net.minecraft.component.type.NbtComponent;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.network.packet.s2c.play.EntityEquipmentUpdateS2CPacket;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.Registries;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Hand;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,6 +49,8 @@ public class Utils {
     public static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.builder().hexColors().useUnusualXRepeatedCharacterHexFormat().build();
     public static final MiniMessage MINI_MESSAGE = MiniMessage.builder().tags(StandardTags.defaults()).build();
     private static final String MODEL_OVERRIDE_KEY = "servercosmeticsModelOverride";
+    private static final String MODEL_BASE_KEY = "servercosmeticsModelBase";
+    private static final String MODEL_BLOCKING_KEY = "servercosmeticsBlockingModel";
 
     public static Text formatDisplayName(String st) {
         StringBuilder sb = new StringBuilder(st.length());
@@ -131,8 +139,7 @@ public class Utils {
     public static ItemStack getTiltedItemStack(ItemStack original, PolymerModelData polymerModel){
         ItemStack itemStack = original.copy();
         ((IItemStack) (Object) itemStack).server_Cosmetics$setItem(polymerModel.item());
-        itemStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(polymerModel.value()));
-        applyModelOverride(itemStack, polymerModel.value());
+        initializeModelData(itemStack, polymerModel.value(), null);
         return itemStack;
     }
 
@@ -181,7 +188,6 @@ public class Utils {
         boolean mutateOriginal = player != null;
         ItemStack workingStack = mutateOriginal ? originalStack : originalStack.copy();
 
-        // Ensure legacy data is migrated without mutating the live stack during network encoding.
         NbtDatafixer.fixItemStackNbt(workingStack);
 
         if (workingStack.isEmpty()) {
@@ -189,73 +195,119 @@ public class Utils {
         }
 
         NbtComponent customDataComponent = workingStack.get(DataComponentTypes.CUSTOM_DATA);
+        if (customDataComponent == null) {
+            return workingStack;
+        }
 
-        if (customDataComponent != null) {
-            NbtCompound nbt = customDataComponent.copyNbt();
+        NbtCompound nbt = customDataComponent.copyNbt();
+        if (!nbt.contains(NEW_NBT_KEY_CUSTOM_ITEM_ID, NbtCompound.STRING_TYPE)) {
+            return workingStack;
+        }
 
-            if (nbt.contains(NEW_NBT_KEY_CUSTOM_ITEM_ID, NbtCompound.STRING_TYPE)) {
-                String itemSkinId = nbt.getString(NEW_NBT_KEY_CUSTOM_ITEM_ID);
-                int overrideModelData = nbt.contains(MODEL_OVERRIDE_KEY, NbtCompound.INT_TYPE) ? nbt.getInt(MODEL_OVERRIDE_KEY) : Integer.MIN_VALUE;
+        String itemSkinId = nbt.getString(NEW_NBT_KEY_CUSTOM_ITEM_ID);
 
-                CustomItemEntry skinEntry = CustomItemRegistry.getCosmetic(itemSkinId);
-                if (skinEntry == null) {
-                    Identifier itemId = Registries.ITEM.getId(workingStack.getItem());
-                    if (itemId != null) {
-                        skinEntry = CustomItemRegistry.getCosmetic(itemSkinId + "_" + itemId);
-                    }
-                }
-
-                if (skinEntry == null) {
-                    clearCosmeticIdentifiers(workingStack);
-                    return workingStack;
-                }
-
-                if (skinEntry.type() != ItemType.ITEM_SKIN) {
-                    if (overrideModelData != Integer.MIN_VALUE) {
-                        workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(overrideModelData));
-                        applyModelOverride(workingStack, overrideModelData);
-                    } else {
-                        CustomModelDataComponent expectedModelData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
-                        if (expectedModelData != null) {
-                            workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, expectedModelData);
-                            applyModelOverride(workingStack, expectedModelData.value());
-                        } else {
-                            workingStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
-                            clearModelOverride(workingStack);
-                        }
-                    }
-                    return workingStack;
-                }
-
-                if (player != null && !Permissions.check(player, skinEntry.permission(), 4)) {
-                    clearCosmeticIdentifiers(workingStack);
-                    return workingStack;
-                }
-
-                if (overrideModelData != Integer.MIN_VALUE) {
-                    workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(overrideModelData));
-                    applyModelOverride(workingStack, overrideModelData);
-                    return workingStack;
-                }
-
-                CustomModelDataComponent expectedModelData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
-                if (expectedModelData != null) {
-                    workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, expectedModelData);
-                    applyModelOverride(workingStack, expectedModelData.value());
-                } else {
-                    workingStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
-                    clearModelOverride(workingStack);
-                }
-
-                return workingStack;
+        CustomItemEntry skinEntry = CustomItemRegistry.getCosmetic(itemSkinId);
+        if (skinEntry == null) {
+            Identifier itemId = Registries.ITEM.getId(workingStack.getItem());
+            if (itemId != null) {
+                skinEntry = CustomItemRegistry.getCosmetic(itemSkinId + "_" + itemId);
             }
         }
+
+        if (skinEntry == null) {
+            clearCosmeticIdentifiers(workingStack);
+            return workingStack;
+        }
+
+        if (mutateOriginal) {
+            NbtComponent definitionData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_DATA);
+            if (definitionData != null) {
+                NbtCompound definitionNbt = definitionData.copyNbt();
+                if (!nbt.contains(MODEL_BASE_KEY, NbtCompound.INT_TYPE) && definitionNbt.contains(MODEL_BASE_KEY, NbtCompound.INT_TYPE)) {
+                    int baseValue = definitionNbt.getInt(MODEL_BASE_KEY);
+                    workingStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                            comp -> comp.apply(dataNbt -> dataNbt.putInt(MODEL_BASE_KEY, baseValue)));
+                    nbt.putInt(MODEL_BASE_KEY, baseValue);
+                }
+                if (!nbt.contains(MODEL_BLOCKING_KEY, NbtCompound.INT_TYPE) && definitionNbt.contains(MODEL_BLOCKING_KEY, NbtCompound.INT_TYPE)) {
+                    int blockingValue = definitionNbt.getInt(MODEL_BLOCKING_KEY);
+                    workingStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                            comp -> comp.apply(dataNbt -> dataNbt.putInt(MODEL_BLOCKING_KEY, blockingValue)));
+                    nbt.putInt(MODEL_BLOCKING_KEY, blockingValue);
+                }
+            }
+        }
+
+        int overrideModelData = readModelValue(nbt, MODEL_OVERRIDE_KEY);
+        int baseModelData = readModelValue(nbt, MODEL_BASE_KEY);
+
+        if (skinEntry.type() != ItemType.ITEM_SKIN) {
+            CustomModelDataComponent expectedModelData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
+            if (expectedModelData != null) {
+                ensureBaseModelData(workingStack, expectedModelData.value());
+                setActiveModel(workingStack, expectedModelData.value());
+            } else if (overrideModelData != Integer.MIN_VALUE) {
+                setActiveModel(workingStack, overrideModelData);
+            } else if (baseModelData != Integer.MIN_VALUE) {
+                setActiveModel(workingStack, baseModelData);
+            } else {
+                workingStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+                clearModelOverride(workingStack);
+            }
+            return workingStack;
+        }
+
+        if (player != null && !Permissions.check(player, skinEntry.permission(), 4)) {
+            clearCosmeticIdentifiers(workingStack);
+            return workingStack;
+        }
+
+        CustomModelDataComponent expectedModelData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
+        if (expectedModelData != null) {
+            ensureBaseModelData(workingStack, expectedModelData.value());
+            if (overrideModelData == Integer.MIN_VALUE) {
+                setActiveModel(workingStack, expectedModelData.value());
+            } else {
+                workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(overrideModelData));
+            }
+        } else {
+            workingStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+            clearModelOverride(workingStack);
+        }
+
         return workingStack;
     }
 
-    public static void applyModelOverride(ItemStack stack, int value) {
+    private static int readModelValue(NbtCompound nbt, String key) {
+        return nbt.contains(key, NbtCompound.INT_TYPE) ? nbt.getInt(key) : Integer.MIN_VALUE;
+    }
+
+    public static void initializeModelData(ItemStack stack, int baseModelValue, @Nullable Integer blockingModelValue) {
+        setActiveModel(stack, baseModelValue);
         stack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
-                comp -> comp.apply(nbt -> nbt.putInt(MODEL_OVERRIDE_KEY, value)));
+                comp -> comp.apply(nbt -> {
+                    nbt.putInt(MODEL_BASE_KEY, baseModelValue);
+                    if (blockingModelValue != null) {
+                        nbt.putInt(MODEL_BLOCKING_KEY, blockingModelValue);
+                    } else {
+                        nbt.remove(MODEL_BLOCKING_KEY);
+                    }
+                }));
+    }
+
+    public static void ensureBaseModelData(ItemStack stack, int baseModelValue) {
+        stack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                comp -> comp.apply(nbt -> {
+                    if (!nbt.contains(MODEL_BASE_KEY, NbtCompound.INT_TYPE)) {
+                        nbt.putInt(MODEL_BASE_KEY, baseModelValue);
+                    }
+                }));
+    }
+
+    public static void setActiveModel(ItemStack stack, int modelValue) {
+        stack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(modelValue));
+        stack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                comp -> comp.apply(nbt -> nbt.putInt(MODEL_OVERRIDE_KEY, modelValue)));
     }
 
     public static void clearModelOverride(ItemStack stack) {
@@ -263,12 +315,114 @@ public class Utils {
                 comp -> comp.apply(nbt -> nbt.remove(MODEL_OVERRIDE_KEY)));
     }
 
+    public static void clearModelOverride(ItemStack stack, boolean removeModelComponent) {
+        clearModelOverride(stack);
+        if (removeModelComponent) {
+            stack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+        }
+    }
+
     public static void clearCosmeticIdentifiers(ItemStack stack) {
         stack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
                 comp -> comp.apply(nbt -> {
                     nbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID);
                     nbt.remove(MODEL_OVERRIDE_KEY);
+                    nbt.remove(MODEL_BASE_KEY);
+                    nbt.remove(MODEL_BLOCKING_KEY);
                 }));
+        stack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+    }
+
+    public static void copyModelData(ItemStack source, ItemStack target) {
+        NbtComponent sourceData = source.get(DataComponentTypes.CUSTOM_DATA);
+        if (sourceData == null) {
+            clearModelOverride(target, true);
+            target.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                    comp -> comp.apply(nbt -> {
+                        nbt.remove(MODEL_BASE_KEY);
+                        nbt.remove(MODEL_BLOCKING_KEY);
+                    }));
+        } else {
+            NbtCompound srcNbt = sourceData.copyNbt();
+            target.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                    comp -> comp.apply(nbt -> {
+                        copyKey(srcNbt, nbt, MODEL_BASE_KEY);
+                        copyKey(srcNbt, nbt, MODEL_BLOCKING_KEY);
+                        copyKey(srcNbt, nbt, MODEL_OVERRIDE_KEY);
+                    }));
+        }
+
+        CustomModelDataComponent sourceModel = source.get(DataComponentTypes.CUSTOM_MODEL_DATA);
+        if (sourceModel != null) {
+            target.set(DataComponentTypes.CUSTOM_MODEL_DATA, sourceModel);
+        } else {
+            target.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+        }
+    }
+
+    private static void copyKey(NbtCompound src, NbtCompound dst, String key) {
+        if (src.contains(key, NbtCompound.INT_TYPE)) {
+            dst.putInt(key, src.getInt(key));
+        } else {
+            dst.remove(key);
+        }
+    }
+
+    public static void updateShieldBlockingState(ServerPlayerEntity player) {
+        boolean blocking = player.isBlocking();
+        Hand activeHand = blocking ? player.getActiveHand() : null;
+
+        boolean mainChanged = updateShieldStack(player.getMainHandStack(), blocking && activeHand == Hand.MAIN_HAND);
+        boolean offChanged = updateShieldStack(player.getOffHandStack(), blocking && activeHand == Hand.OFF_HAND);
+
+        if (mainChanged || offChanged) {
+            player.playerScreenHandler.sendContentUpdates();
+
+            List<Pair<EquipmentSlot, ItemStack>> updates = new ArrayList<>();
+            if (mainChanged) {
+                updates.add(new Pair<>(EquipmentSlot.MAINHAND, player.getMainHandStack().copy()));
+            }
+            if (offChanged) {
+                updates.add(new Pair<>(EquipmentSlot.OFFHAND, player.getOffHandStack().copy()));
+            }
+
+            if (!updates.isEmpty()) {
+                player.getServerWorld().getChunkManager().sendToNearbyPlayers(player,
+                        new EntityEquipmentUpdateS2CPacket(player.getId(), updates));
+            }
+        }
+    }
+
+    private static boolean updateShieldStack(ItemStack stack, boolean useBlockingModel) {
+        if (stack == null || stack.isEmpty()) {
+            return false;
+        }
+
+        NbtComponent data = stack.get(DataComponentTypes.CUSTOM_DATA);
+        if (data == null) {
+            return false;
+        }
+
+        NbtCompound nbt = data.copyNbt();
+        if (!nbt.contains(MODEL_BLOCKING_KEY, NbtCompound.INT_TYPE)) {
+            return false;
+        }
+
+        int baseModel = readModelValue(nbt, MODEL_BASE_KEY);
+        int blockingModel = nbt.getInt(MODEL_BLOCKING_KEY);
+        int currentModel = readModelValue(nbt, MODEL_OVERRIDE_KEY);
+        if (currentModel == Integer.MIN_VALUE) {
+            currentModel = baseModel;
+        }
+
+        int desiredModel = useBlockingModel ? blockingModel : (baseModel != Integer.MIN_VALUE ? baseModel : blockingModel);
+
+        if (currentModel == desiredModel) {
+            return false;
+        }
+
+        setActiveModel(stack, desiredModel);
+        return true;
     }
 
     public static ItemStack filterItemStack(ItemStack originalStack) {

--- a/src/main/java/com/zefir/servercosmetics/util/Utils.java
+++ b/src/main/java/com/zefir/servercosmetics/util/Utils.java
@@ -172,15 +172,21 @@ public class Utils {
     }
 
     public static ItemStack filterItemStack(ItemStack originalStack, ServerPlayerEntity player) {
-        NbtDatafixer.fixItemStackNbt(originalStack);
-        ItemStack stack = originalStack.copy();
-
-
-        if (stack == null || stack.isEmpty()) {
-            return stack;
+        if (originalStack == null || originalStack.isEmpty()) {
+            return originalStack;
         }
 
-        NbtComponent customDataComponent = stack.get(DataComponentTypes.CUSTOM_DATA);
+        boolean mutateOriginal = player != null;
+        ItemStack workingStack = mutateOriginal ? originalStack : originalStack.copy();
+
+        // Ensure legacy data is migrated without mutating the live stack during network encoding.
+        NbtDatafixer.fixItemStackNbt(workingStack);
+
+        if (workingStack.isEmpty()) {
+            return workingStack;
+        }
+
+        NbtComponent customDataComponent = workingStack.get(DataComponentTypes.CUSTOM_DATA);
 
         if (customDataComponent != null) {
             NbtCompound nbt = customDataComponent.copyNbt();
@@ -190,27 +196,31 @@ public class Utils {
 
                 CustomItemEntry skinEntry = CustomItemRegistry.getCosmetic(itemSkinId);
                 if (skinEntry == null) {
-                    skinEntry = CustomItemRegistry.getCosmetic(itemSkinId + "_" + stack.getItem());
+                    skinEntry = CustomItemRegistry.getCosmetic(itemSkinId + "_" + workingStack.getItem());
                 }
 
                 if (skinEntry == null) {
-                    stack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp -> comp.apply(currentNbt -> currentNbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID)));
-                    return stack;
+                    workingStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp -> comp.apply(currentNbt -> currentNbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID)));
+                    return workingStack;
                 } else if (skinEntry.type() == ItemType.ITEM_SKIN) {
-                    if(player != null && !Permissions.check(player, skinEntry.permission(), 4)) {
-                        originalStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp -> comp.apply(currentNbt -> currentNbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID)));
-                        return originalStack;
+                    if (player != null && !Permissions.check(player, skinEntry.permission(), 4)) {
+                        workingStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp -> comp.apply(currentNbt -> currentNbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID)));
+                        return workingStack;
                     }
 
                 }
 
                 CustomModelDataComponent expectedModelData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
-                stack.set(DataComponentTypes.CUSTOM_MODEL_DATA, expectedModelData);
+                if (expectedModelData != null) {
+                    workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, expectedModelData);
+                } else {
+                    workingStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+                }
 
-                return stack;
+                return workingStack;
             }
         }
-        return originalStack;
+        return workingStack;
     }
 
     public static ItemStack filterItemStack(ItemStack originalStack) {

--- a/src/main/java/com/zefir/servercosmetics/util/Utils.java
+++ b/src/main/java/com/zefir/servercosmetics/util/Utils.java
@@ -42,6 +42,7 @@ import static com.zefir.servercosmetics.datafixer.NbtDatafixer.NEW_NBT_KEY_CUSTO
 public class Utils {
     public static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.builder().hexColors().useUnusualXRepeatedCharacterHexFormat().build();
     public static final MiniMessage MINI_MESSAGE = MiniMessage.builder().tags(StandardTags.defaults()).build();
+    private static final String MODEL_OVERRIDE_KEY = "servercosmeticsModelOverride";
 
     public static Text formatDisplayName(String st) {
         StringBuilder sb = new StringBuilder(st.length());
@@ -131,6 +132,7 @@ public class Utils {
         ItemStack itemStack = original.copy();
         ((IItemStack) (Object) itemStack).server_Cosmetics$setItem(polymerModel.item());
         itemStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(polymerModel.value()));
+        applyModelOverride(itemStack, polymerModel.value());
         return itemStack;
     }
 
@@ -193,34 +195,80 @@ public class Utils {
 
             if (nbt.contains(NEW_NBT_KEY_CUSTOM_ITEM_ID, NbtCompound.STRING_TYPE)) {
                 String itemSkinId = nbt.getString(NEW_NBT_KEY_CUSTOM_ITEM_ID);
+                int overrideModelData = nbt.contains(MODEL_OVERRIDE_KEY, NbtCompound.INT_TYPE) ? nbt.getInt(MODEL_OVERRIDE_KEY) : Integer.MIN_VALUE;
 
                 CustomItemEntry skinEntry = CustomItemRegistry.getCosmetic(itemSkinId);
                 if (skinEntry == null) {
-                    skinEntry = CustomItemRegistry.getCosmetic(itemSkinId + "_" + workingStack.getItem());
+                    Identifier itemId = Registries.ITEM.getId(workingStack.getItem());
+                    if (itemId != null) {
+                        skinEntry = CustomItemRegistry.getCosmetic(itemSkinId + "_" + itemId);
+                    }
                 }
 
                 if (skinEntry == null) {
-                    workingStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp -> comp.apply(currentNbt -> currentNbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID)));
+                    clearCosmeticIdentifiers(workingStack);
                     return workingStack;
-                } else if (skinEntry.type() == ItemType.ITEM_SKIN) {
-                    if (player != null && !Permissions.check(player, skinEntry.permission(), 4)) {
-                        workingStack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT, comp -> comp.apply(currentNbt -> currentNbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID)));
-                        return workingStack;
-                    }
+                }
 
+                if (skinEntry.type() != ItemType.ITEM_SKIN) {
+                    if (overrideModelData != Integer.MIN_VALUE) {
+                        workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(overrideModelData));
+                        applyModelOverride(workingStack, overrideModelData);
+                    } else {
+                        CustomModelDataComponent expectedModelData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
+                        if (expectedModelData != null) {
+                            workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, expectedModelData);
+                            applyModelOverride(workingStack, expectedModelData.value());
+                        } else {
+                            workingStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+                            clearModelOverride(workingStack);
+                        }
+                    }
+                    return workingStack;
+                }
+
+                if (player != null && !Permissions.check(player, skinEntry.permission(), 4)) {
+                    clearCosmeticIdentifiers(workingStack);
+                    return workingStack;
+                }
+
+                if (overrideModelData != Integer.MIN_VALUE) {
+                    workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, new CustomModelDataComponent(overrideModelData));
+                    applyModelOverride(workingStack, overrideModelData);
+                    return workingStack;
                 }
 
                 CustomModelDataComponent expectedModelData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
                 if (expectedModelData != null) {
                     workingStack.set(DataComponentTypes.CUSTOM_MODEL_DATA, expectedModelData);
+                    applyModelOverride(workingStack, expectedModelData.value());
                 } else {
                     workingStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
+                    clearModelOverride(workingStack);
                 }
 
                 return workingStack;
             }
         }
         return workingStack;
+    }
+
+    public static void applyModelOverride(ItemStack stack, int value) {
+        stack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                comp -> comp.apply(nbt -> nbt.putInt(MODEL_OVERRIDE_KEY, value)));
+    }
+
+    public static void clearModelOverride(ItemStack stack) {
+        stack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                comp -> comp.apply(nbt -> nbt.remove(MODEL_OVERRIDE_KEY)));
+    }
+
+    public static void clearCosmeticIdentifiers(ItemStack stack) {
+        stack.apply(DataComponentTypes.CUSTOM_DATA, NbtComponent.DEFAULT,
+                comp -> comp.apply(nbt -> {
+                    nbt.remove(NEW_NBT_KEY_CUSTOM_ITEM_ID);
+                    nbt.remove(MODEL_OVERRIDE_KEY);
+                }));
     }
 
     public static ItemStack filterItemStack(ItemStack originalStack) {

--- a/src/main/java/com/zefir/servercosmetics/util/Utils.java
+++ b/src/main/java/com/zefir/servercosmetics/util/Utils.java
@@ -245,11 +245,18 @@ public class Utils {
             CustomModelDataComponent expectedModelData = skinEntry.itemStack().get(DataComponentTypes.CUSTOM_MODEL_DATA);
             if (expectedModelData != null) {
                 ensureBaseModelData(workingStack, expectedModelData.value());
-                setActiveModel(workingStack, expectedModelData.value());
-            } else if (overrideModelData != Integer.MIN_VALUE) {
-                setActiveModel(workingStack, overrideModelData);
-            } else if (baseModelData != Integer.MIN_VALUE) {
-                setActiveModel(workingStack, baseModelData);
+                if (baseModelData == Integer.MIN_VALUE) {
+                    baseModelData = expectedModelData.value();
+                }
+            }
+
+            int desiredModel = overrideModelData != Integer.MIN_VALUE
+                    ? overrideModelData
+                    : (baseModelData != Integer.MIN_VALUE ? baseModelData
+                    : (expectedModelData != null ? expectedModelData.value() : Integer.MIN_VALUE));
+
+            if (desiredModel != Integer.MIN_VALUE) {
+                setActiveModel(workingStack, desiredModel);
             } else {
                 workingStack.remove(DataComponentTypes.CUSTOM_MODEL_DATA);
                 clearModelOverride(workingStack);


### PR DESCRIPTION
Prevent [Utils.filterItemStack] from mutating shared [ItemStack] 
instances during equipment packet encoding.
Ensure Polymer component data stays consistent by working on a defensive copy when no player context exists.
Eliminate the ClientboundSetEquipment encoding crash triggered when nearby players receive equipment updates.

[errorlog.txt](https://github.com/user-attachments/files/23403376/errorlog.txt)